### PR TITLE
Refactor Tests

### DIFF
--- a/catalog/core/catalog-core-api/src/main/java/ddf/catalog/source/SourceMetrics.java
+++ b/catalog/core/catalog-core-api/src/main/java/ddf/catalog/source/SourceMetrics.java
@@ -23,34 +23,14 @@ package ddf.catalog.source;
  * @author rodgersh
  */
 public interface SourceMetrics {
+  
+  public static final String METRICS_PREFIX = "ddf.catalog.source";
 
-  /** Package name for the JMX MBean where metrics for {@link Source}s are stored. */
-  public static final String MBEAN_PACKAGE_NAME = "ddf.metrics.catalog.source";
+  public static final String QUERY_SCOPE = "query";
 
-  /**
-   * Name of the JMX MBean scope for source-level metrics tracking exceptions while querying a
-   * specific {@link Source}
-   */
-  public static final String EXCEPTIONS_SCOPE = "Exceptions";
+  public static final String REQUEST_TYPE = "request";
 
-  /**
-   * Name of the JMX MBean scope for source-level metrics tracking query count while querying a
-   * specific {@link Source}
-   */
-  public static final String QUERIES_SCOPE = "Queries";
+  public static final String RESPONSE_TYPE = "response";
 
-  /**
-   * Name of the JMX MBean scope for source-level metrics tracking total results returned while
-   * querying a specific {@link Source}
-   */
-  public static final String QUERIES_TOTAL_RESULTS_SCOPE = "Queries.TotalResults";
-
-  /**
-   * Update a source-level metric.
-   *
-   * @param sourceId ID of the {@link Source} to update metrics for
-   * @param metricName name of the metric to update
-   * @param incrementAmount amount to increment the metric's count by
-   */
-  public void updateMetric(String sourceId, String metricName, int incrementAmount);
+  public static final String EXCEPTION_TYPE = "exception";
 }

--- a/catalog/core/catalog-core-api/src/main/java/ddf/catalog/source/SourceMetrics.java
+++ b/catalog/core/catalog-core-api/src/main/java/ddf/catalog/source/SourceMetrics.java
@@ -24,13 +24,13 @@ package ddf.catalog.source;
  */
 public interface SourceMetrics {
 
-  public static final String METRICS_PREFIX = "ddf.catalog.source";
+  String METRICS_PREFIX = "ddf.catalog.source";
 
-  public static final String QUERY_SCOPE = "query";
+  String QUERY_SCOPE = "query";
 
-  public static final String REQUEST_TYPE = "request";
+  String REQUEST_TYPE = "request";
 
-  public static final String RESPONSE_TYPE = "response";
+  String RESPONSE_TYPE = "response";
 
-  public static final String EXCEPTION_TYPE = "exception";
+  String EXCEPTION_TYPE = "exception";
 }

--- a/catalog/core/catalog-core-api/src/main/java/ddf/catalog/source/SourceMetrics.java
+++ b/catalog/core/catalog-core-api/src/main/java/ddf/catalog/source/SourceMetrics.java
@@ -23,7 +23,7 @@ package ddf.catalog.source;
  * @author rodgersh
  */
 public interface SourceMetrics {
-  
+
   public static final String METRICS_PREFIX = "ddf.catalog.source";
 
   public static final String QUERY_SCOPE = "query";

--- a/catalog/core/catalog-core-metricsplugin/src/test/java/ddf/catalog/metrics/CatalogMetricsTest.java
+++ b/catalog/core/catalog-core-metricsplugin/src/test/java/ddf/catalog/metrics/CatalogMetricsTest.java
@@ -13,6 +13,11 @@
  */
 package ddf.catalog.metrics;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
 import ddf.catalog.data.Metacard;
 import ddf.catalog.data.types.Core;
 import ddf.catalog.federation.FederationException;
@@ -29,18 +34,12 @@ import ddf.catalog.source.SourceUnavailableException;
 import ddf.catalog.source.UnsupportedQueryException;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.util.*;
 import org.codice.ddf.configuration.SystemInfo;
 import org.codice.ddf.lib.metrics.registry.MeterRegistryService;
 import org.junit.Before;
 import org.junit.Test;
 import org.opengis.filter.Filter;
-
-import java.util.*;
-
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.is;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 /**
  * Tests {@link CatalogMetrics}
@@ -253,5 +252,4 @@ public class CatalogMetricsTest {
 
     assertThat(underTest.resourceRetrival.count(), is(1.0));
   }
-
 }

--- a/catalog/core/catalog-core-metricsplugin/src/test/java/ddf/catalog/metrics/CatalogMetricsTest.java
+++ b/catalog/core/catalog-core-metricsplugin/src/test/java/ddf/catalog/metrics/CatalogMetricsTest.java
@@ -13,11 +13,6 @@
  */
 package ddf.catalog.metrics;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.is;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
-
 import ddf.catalog.data.Metacard;
 import ddf.catalog.data.types.Core;
 import ddf.catalog.federation.FederationException;
@@ -25,37 +20,27 @@ import ddf.catalog.filter.FilterAdapter;
 import ddf.catalog.filter.FilterBuilder;
 import ddf.catalog.filter.proxy.adapter.GeotoolsFilterAdapterImpl;
 import ddf.catalog.filter.proxy.builder.GeotoolsFilterBuilder;
-import ddf.catalog.operation.CreateRequest;
-import ddf.catalog.operation.CreateResponse;
-import ddf.catalog.operation.DeleteRequest;
-import ddf.catalog.operation.DeleteResponse;
-import ddf.catalog.operation.ProcessingDetails;
-import ddf.catalog.operation.QueryRequest;
-import ddf.catalog.operation.QueryResponse;
-import ddf.catalog.operation.ResourceResponse;
-import ddf.catalog.operation.Update;
-import ddf.catalog.operation.UpdateRequest;
-import ddf.catalog.operation.UpdateResponse;
+import ddf.catalog.operation.*;
 import ddf.catalog.operation.impl.ProcessingDetailsImpl;
 import ddf.catalog.operation.impl.QueryImpl;
 import ddf.catalog.operation.impl.QueryRequestImpl;
 import ddf.catalog.operation.impl.QueryResponseImpl;
 import ddf.catalog.source.SourceUnavailableException;
 import ddf.catalog.source.UnsupportedQueryException;
-import io.micrometer.core.instrument.Meter;
 import io.micrometer.core.instrument.MeterRegistry;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Date;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.codice.ddf.configuration.SystemInfo;
 import org.codice.ddf.lib.metrics.registry.MeterRegistryService;
-import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.opengis.filter.Filter;
+
+import java.util.*;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 /**
  * Tests {@link CatalogMetrics}
@@ -79,22 +64,11 @@ public class CatalogMetricsTest {
 
   @Before
   public void setup() {
+    meterRegistry = new SimpleMeterRegistry();
     meterRegistryService = mock(MeterRegistryService.class);
-    meterRegistry = mock(MeterRegistry.class);
     when(meterRegistryService.getMeterRegistry()).thenReturn(meterRegistry);
     underTest = new CatalogMetrics(filterAdapter, meterRegistryService);
     System.setProperty(SystemInfo.SITE_NAME, "testSite");
-  }
-
-  @After
-  public void tearDown() {
-
-    // Remove the metrics created when setup() instantiated CatalogMetrics -
-    // otherwise get lots of exceptions that metric already exists which fill
-    // up the log to point of Travis CI build failing
-    for (Meter meter : underTest.meterRegistry.getMeters()) {
-      underTest.meterRegistry.remove(meter);
-    }
   }
 
   @Test
@@ -102,8 +76,8 @@ public class CatalogMetricsTest {
     QueryRequest query = new QueryRequestImpl(new QueryImpl(idFilter));
     underTest.process(query);
 
-    assertThat(underTest.queries.count(), is(1L));
-    assertThat(underTest.comparisonQueries.count(), is(1L));
+    assertThat(underTest.queries.count(), is(1.0));
+    assertThat(underTest.comparisonQueries.count(), is(1.0));
   }
 
   @Test
@@ -119,7 +93,7 @@ public class CatalogMetricsTest {
             new QueryImpl(idFilter), Arrays.asList("fedSource1Id", "fedSource2Id"));
     underTest.process(query);
 
-    assertThat(underTest.federatedQueries.count(), is(3L));
+    assertThat(underTest.federatedQueries.count(), is(3.0));
   }
 
   @Test
@@ -134,7 +108,7 @@ public class CatalogMetricsTest {
     query = new QueryRequestImpl(new QueryImpl(idFilter), Arrays.asList("localSourceId"));
     underTest.process(query);
 
-    assertThat(underTest.federatedQueries.count(), is(0L));
+    assertThat(underTest.federatedQueries.count(), is(0.0));
   }
 
   @Test
@@ -145,7 +119,7 @@ public class CatalogMetricsTest {
     QueryRequest query = new QueryRequestImpl(new QueryImpl(geoFilter));
     underTest.process(query);
 
-    assertThat(underTest.spatialQueries.count(), is(1L));
+    assertThat(underTest.spatialQueries.count(), is(1.0));
   }
 
   @Test
@@ -155,7 +129,7 @@ public class CatalogMetricsTest {
     QueryRequest query = new QueryRequestImpl(new QueryImpl(temporalFilter));
     underTest.process(query);
 
-    assertThat(underTest.temporalQueries.count(), is(1L));
+    assertThat(underTest.temporalQueries.count(), is(1.0));
   }
 
   @Test
@@ -172,7 +146,7 @@ public class CatalogMetricsTest {
     QueryRequest query = new QueryRequestImpl(new QueryImpl(functionFilter));
     underTest.process(query);
 
-    assertThat(underTest.functionQueries.count(), is(1L));
+    assertThat(underTest.functionQueries.count(), is(1.0));
   }
 
   @Test
@@ -182,7 +156,7 @@ public class CatalogMetricsTest {
     QueryRequest query = new QueryRequestImpl(new QueryImpl(xpathFilter));
     underTest.process(query);
 
-    assertThat(underTest.xpathQueries.count(), is(1L));
+    assertThat(underTest.xpathQueries.count(), is(1.0));
   }
 
   @Test
@@ -192,7 +166,7 @@ public class CatalogMetricsTest {
     QueryRequest query = new QueryRequestImpl(new QueryImpl(fuzzyFilter));
     underTest.process(query);
 
-    assertThat(underTest.fuzzyQueries.count(), is(1L));
+    assertThat(underTest.fuzzyQueries.count(), is(1.0));
   }
 
   @Test
@@ -223,10 +197,10 @@ public class CatalogMetricsTest {
 
     underTest.process(response);
 
-    assertThat(underTest.exceptions.count(), is(4L));
-    assertThat(underTest.unsupportedQueryExceptions.count(), is(1L));
-    assertThat(underTest.sourceUnavailableExceptions.count(), is(1L));
-    assertThat(underTest.federationExceptions.count(), is(1L));
+    assertThat(underTest.exceptions.count(), is(4.0));
+    assertThat(underTest.unsupportedQueryExceptions.count(), is(1.0));
+    assertThat(underTest.sourceUnavailableExceptions.count(), is(1.0));
+    assertThat(underTest.federationExceptions.count(), is(1.0));
   }
 
   @Test
@@ -240,7 +214,7 @@ public class CatalogMetricsTest {
 
     underTest.process(response);
 
-    assertThat(underTest.createdMetacards.count(), is(100L));
+    assertThat(underTest.createdMetacards.count(), is(100.0));
   }
 
   @Test
@@ -254,7 +228,7 @@ public class CatalogMetricsTest {
 
     underTest.process(response);
 
-    assertThat(underTest.updatedMetacards.count(), is(100L));
+    assertThat(underTest.updatedMetacards.count(), is(100.0));
   }
 
   @Test
@@ -268,7 +242,7 @@ public class CatalogMetricsTest {
 
     underTest.process(response);
 
-    assertThat(underTest.deletedMetacards.count(), is(100L));
+    assertThat(underTest.deletedMetacards.count(), is(100.0));
   }
 
   @Test
@@ -277,6 +251,7 @@ public class CatalogMetricsTest {
 
     underTest.process(response);
 
-    assertThat(underTest.resourceRetrival.count(), is(1L));
+    assertThat(underTest.resourceRetrival.count(), is(1.0));
   }
+
 }

--- a/catalog/core/catalog-core-sourcemetricsplugin/pom.xml
+++ b/catalog/core/catalog-core-sourcemetricsplugin/pom.xml
@@ -55,6 +55,11 @@
             <version>${project.version}</version>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>ddf.catalog.core</groupId>
+            <artifactId>catalog-core-api-impl</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <build>
         <plugins>
@@ -112,7 +117,6 @@
                                             <value>COVEREDRATIO</value>
                                             <minimum>0.54</minimum>
                                         </limit>
-                                        
                                     </limits>
                                 </rule>
                             </rules>

--- a/catalog/core/catalog-core-sourcemetricsplugin/src/main/java/ddf/catalog/metrics/source/SourceMetricsImpl.java
+++ b/catalog/core/catalog-core-sourcemetricsplugin/src/main/java/ddf/catalog/metrics/source/SourceMetricsImpl.java
@@ -13,6 +13,8 @@
  */
 package ddf.catalog.metrics.source;
 
+import static ddf.catalog.source.SourceMetrics.*;
+
 import ddf.catalog.data.Metacard;
 import ddf.catalog.data.Result;
 import ddf.catalog.operation.ProcessingDetails;
@@ -24,14 +26,11 @@ import ddf.catalog.plugin.PreFederatedQueryPlugin;
 import ddf.catalog.plugin.StopProcessingException;
 import ddf.catalog.source.Source;
 import io.micrometer.core.instrument.MeterRegistry;
+import java.util.List;
+import java.util.Set;
 import org.codice.ddf.lib.metrics.registry.MeterRegistryService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.util.List;
-import java.util.Set;
-
-import static ddf.catalog.source.SourceMetrics.*;
 
 public class SourceMetricsImpl implements PreFederatedQueryPlugin, PostFederatedQueryPlugin {
 
@@ -51,9 +50,12 @@ public class SourceMetricsImpl implements PreFederatedQueryPlugin, PostFederated
   public QueryRequest process(Source source, QueryRequest input)
       throws PluginExecutionException, StopProcessingException {
 
-//    A DistributionSummary can be instead by replacing counter() by summary() and increment() by record(). This applies
-//    equally to any other metric set in this class and retrieved in SourceMetricImplTest
-    meterRegistry.counter(source.getId() + "." + METRICS_PREFIX + "." + QUERY_SCOPE + "." + REQUEST_TYPE).increment();
+    //    A DistributionSummary can be instead by replacing counter() by summary() and increment()
+    // by record(). This applies
+    //    equally to any other metric set in this class and retrieved in SourceMetricImplTest
+    meterRegistry
+        .counter(source.getId() + "." + METRICS_PREFIX + "." + QUERY_SCOPE + "." + REQUEST_TYPE)
+        .increment();
     return input;
   }
 
@@ -66,18 +68,26 @@ public class SourceMetricsImpl implements PreFederatedQueryPlugin, PostFederated
       Set<ProcessingDetails> processingDetails = input.getProcessingDetails();
       List<Result> results = input.getResults();
 
-      processingDetails.stream()
-              .filter(ProcessingDetails::hasException)
-              .map(ProcessingDetails::getSourceId)
-              .forEach(id -> {
-                meterRegistry.counter(id  + "." + METRICS_PREFIX + "." + QUERY_SCOPE + "."+ EXCEPTION_TYPE).increment();
+      processingDetails
+          .stream()
+          .filter(ProcessingDetails::hasException)
+          .map(ProcessingDetails::getSourceId)
+          .forEach(
+              id -> {
+                meterRegistry
+                    .counter(id + "." + METRICS_PREFIX + "." + QUERY_SCOPE + "." + EXCEPTION_TYPE)
+                    .increment();
               });
 
-      results.stream()
-              .map(Result::getMetacard)
-              .map(Metacard::getSourceId)
-              .forEach(id -> {
-                meterRegistry.counter(id  + "." + METRICS_PREFIX + "." + QUERY_SCOPE + "."+ RESPONSE_TYPE).increment();
+      results
+          .stream()
+          .map(Result::getMetacard)
+          .map(Metacard::getSourceId)
+          .forEach(
+              id -> {
+                meterRegistry
+                    .counter(id + "." + METRICS_PREFIX + "." + QUERY_SCOPE + "." + RESPONSE_TYPE)
+                    .increment();
               });
     }
     return input;

--- a/catalog/core/catalog-core-sourcemetricsplugin/src/main/java/ddf/catalog/metrics/source/SourceMetricsImpl.java
+++ b/catalog/core/catalog-core-sourcemetricsplugin/src/main/java/ddf/catalog/metrics/source/SourceMetricsImpl.java
@@ -24,111 +24,26 @@ import ddf.catalog.plugin.StopProcessingException;
 import ddf.catalog.source.CatalogProvider;
 import ddf.catalog.source.FederatedSource;
 import ddf.catalog.source.Source;
-import io.micrometer.core.instrument.Counter;
-import io.micrometer.core.instrument.DistributionSummary;
-import io.micrometer.core.instrument.Meter;
 import io.micrometer.core.instrument.MeterRegistry;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import org.apache.commons.lang.StringUtils;
 import org.codice.ddf.lib.metrics.registry.MeterRegistryService;
-import org.codice.ddf.platform.util.StandardThreadFactoryBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-/**
- * This class manages the metrics for individual {@link CatalogProvider} and {@link FederatedSource}
- * {@link Source}s. These metrics currently include the count of queries, results per query, and
- * exceptions per {@link Source}.
- *
- * <p>The metrics are created when the {@link Source} is created and deleted when the {@link Source}
- * is deleted.
- *
- * @author rodgersh
- */
+import java.util.*;
+
+import static ddf.catalog.source.SourceMetrics.*;
+
 public class SourceMetricsImpl implements PreFederatedQueryPlugin, PostFederatedQueryPlugin {
-
-  /** Package name for the JMX MBean where metrics for {@link Source}s are stored. */
-  public static final String MBEAN_PACKAGE_NAME = "ddf.metrics.catalog.source";
-
-  /** Prefix for metrics */
-  public static final String METRICS_PREFIX = "ddf.catalog.source";
-
-  /**
-   * Name of the JMX MBean scope for source-level metrics tracking exceptions while querying a
-   * specific {@link Source}
-   */
-  public static final String EXCEPTIONS_SCOPE = "exceptions";
-
-  /**
-   * Name of the JMX MBean scope for source-level metrics tracking query count while querying a
-   * specific {@link Source}
-   */
-  public static final String QUERIES_SCOPE = "queries";
-
-  /**
-   * Name of the JMX MBean scope for source-level metrics tracking total results returned while
-   * querying a specific {@link Source}
-   */
-  public static final String QUERIES_TOTAL_RESULTS_SCOPE = "queries.totalresults";
-
-  public static final String DERIVE_DATA_SOURCE_TYPE = "DERIVE";
-
-  public static final String GAUGE_DATA_SOURCE_TYPE = "GAUGE";
-
-  public static final String COUNT_MBEAN_ATTRIBUTE_NAME = "Count";
-
-  public static final String MEAN_MBEAN_ATTRIBUTE_NAME = "Mean";
 
   private static final Logger LOGGER = LoggerFactory.getLogger(SourceMetricsImpl.class);
 
-  private static final String ALPHA_NUMERIC_REGEX = "[^a-zA-Z0-9]";
-
   private final MeterRegistry meterRegistry;
-
-  // Map of sourceId to Source's metric data
-  protected Map<String, SourceMetric> metrics = new HashMap<String, SourceMetric>();
-
-  // Injected list of CatalogProviders and FederatedSources
-  // that is kept updated by container, e.g., with latest sourceIds
-  private List<CatalogProvider> catalogProviders = new ArrayList<CatalogProvider>();
-
-  private List<FederatedSource> federatedSources = new ArrayList<FederatedSource>();
-
-  // Map of Source to sourceId - used to detect if sourceId has been changed since last metric
-  // update
-  private Map<Source, String> sourceToSourceIdMap = new HashMap<Source, String>();
-
-  private ExecutorService executorPool;
 
   public SourceMetricsImpl(MeterRegistryService meterRegistryService) {
     if (meterRegistryService == null) {
       LOGGER.warn("Meter Registry Service is not available");
     }
-
     meterRegistry = meterRegistryService.getMeterRegistry();
-  }
-
-  public List<CatalogProvider> getCatalogProviders() {
-    return catalogProviders;
-  }
-
-  public void setCatalogProviders(List<CatalogProvider> catalogProviders) {
-    this.catalogProviders = catalogProviders;
-  }
-
-  public List<FederatedSource> getFederatedSources() {
-    return federatedSources;
-  }
-
-  public void setFederatedSources(List<FederatedSource> federatedSources) {
-    this.federatedSources = federatedSources;
   }
 
   // PreFederatedQuery
@@ -136,13 +51,11 @@ public class SourceMetricsImpl implements PreFederatedQueryPlugin, PostFederated
   public QueryRequest process(Source source, QueryRequest input)
       throws PluginExecutionException, StopProcessingException {
 
-    LOGGER.trace("ENTERING: process (for PreFederatedQueryPlugin)");
-
-    // Number of Queries metric per Source
-    updateMetric(source.getId(), QUERIES_SCOPE, 1);
-
-    LOGGER.trace("EXITING: process (for PreFederatedQueryPlugin)");
-
+//    A DistributionSummary can be instead by replacing counter() by summary() and increment() by record. This applies
+//    equally to any other metric set in this class and retrieved in SourceMetricImplTest
+    meterRegistry.counter(source.getId() + "." + METRICS_PREFIX + "." +
+            QUERY_SCOPE + "." + REQUEST_TYPE)
+            .increment();
     return input;
   }
 
@@ -157,254 +70,27 @@ public class SourceMetricsImpl implements PreFederatedQueryPlugin, PostFederated
       Set<ProcessingDetails> processingDetails = input.getProcessingDetails();
       List<Result> results = input.getResults();
 
-      // Total Exceptions metric per Source
       Iterator<ProcessingDetails> iterator = processingDetails.iterator();
       while (iterator.hasNext()) {
         ProcessingDetails next = iterator.next();
         if (next != null && next.getException() != null) {
           String sourceId = next.getSourceId();
-          updateMetric(sourceId, EXCEPTIONS_SCOPE, 1);
+          meterRegistry.counter(sourceId + "." + METRICS_PREFIX + "." + QUERY_SCOPE + "."+ EXCEPTION_TYPE).increment();
         }
       }
 
       Map<String, Integer> totalHitsPerSource = new HashMap<String, Integer>();
-
       for (Result result : results) {
         String sourceId = result.getMetacard().getSourceId();
-        if (totalHitsPerSource.containsKey(sourceId)) {
-          totalHitsPerSource.put(sourceId, totalHitsPerSource.get(sourceId) + 1);
-        } else {
-          // First detection of this new source ID in the results list -
-          // initialize the Total Query Result Count for this Source
-          totalHitsPerSource.put(sourceId, 1);
-        }
+        totalHitsPerSource.put(sourceId, totalHitsPerSource.getOrDefault(sourceId, 0));
       }
-
-      // Total Query Results metric per Source
       for (Map.Entry<String, Integer> source : totalHitsPerSource.entrySet()) {
-        updateMetric(source.getKey(), QUERIES_TOTAL_RESULTS_SCOPE, source.getValue());
+        meterRegistry.counter(source.getKey() + "." + METRICS_PREFIX + "." + QUERY_SCOPE + "." + RESPONSE_TYPE).increment();
       }
     }
 
     LOGGER.trace("EXITING: process (for PostFederatedQueryPlugin)");
 
     return input;
-  }
-
-  public void updateMetric(String sourceId, String name, int incrementAmount) {
-
-    LOGGER.debug("sourceId = {},   name = {}", sourceId, name);
-
-    if (StringUtils.isBlank(sourceId) || StringUtils.isBlank(name)) {
-      return;
-    }
-
-    String mapKey = sourceId + "." + name;
-    SourceMetric sourceMetric = metrics.get(mapKey);
-
-    if (sourceMetric == null) {
-      LOGGER.debug("sourceMetric is null for {} - creating metric now", mapKey);
-      // Loop through list of all sources until find the sourceId whose metric is being
-      // updated
-      boolean created = createMetric(catalogProviders, sourceId);
-      if (!created) {
-        createMetric(federatedSources, sourceId);
-      }
-      sourceMetric = metrics.get(mapKey);
-    }
-
-    // If this metric already exists, then just update its MBean
-    if (sourceMetric != null) {
-      LOGGER.debug("CASE 1: Metric already exists for {}", mapKey);
-      if (sourceMetric.isHistogram()) {
-        DistributionSummary metric = (DistributionSummary) sourceMetric.getMetric();
-        LOGGER.debug("Updating histogram metric {} by amount of {}", name, incrementAmount);
-        metric.record(incrementAmount);
-      } else {
-        Counter metric = (Counter) sourceMetric.getMetric();
-        LOGGER.debug("Updating metric {} by amount of {}", name, incrementAmount);
-        metric.increment(incrementAmount);
-      }
-      return;
-    }
-  }
-
-  private boolean createMetric(List<? extends Source> sources, String sourceId) {
-    for (Source source : sources) {
-      if (source.getId().equals(sourceId)) {
-        LOGGER.debug("Found sourceId = {} in sources list", sourceId);
-        if (sourceToSourceIdMap.containsKey(source)) {
-          // Source's ID must have changed since it is in this map but not in the metrics
-          // map
-          // Delete SourceMetrics for Source's "old" sourceId
-          String oldSourceId = sourceToSourceIdMap.get(source);
-          LOGGER.debug("CASE 2: source {} exists but has oldSourceId = {}", sourceId, oldSourceId);
-
-          // Create metrics for Source with new sourceId
-          createMetric(
-              sourceId, METRICS_PREFIX + "." + QUERIES_TOTAL_RESULTS_SCOPE, MetricType.HISTOGRAM);
-          createMetric(sourceId, METRICS_PREFIX + "." + QUERIES_SCOPE, MetricType.COUNTER);
-          createMetric(sourceId, METRICS_PREFIX + "." + EXCEPTIONS_SCOPE, MetricType.COUNTER);
-
-          // Add Source to map with its new sourceId
-          sourceToSourceIdMap.put(source, sourceId);
-        } else {
-          // This is a brand new Source - create metrics for it
-          // (Should rarely happen since Sources typically have their metrics created
-          // when the Source itself is created via the addingSource() method. This could
-          // happen if sourceId = null when Source originally created and then its metric
-          // needs updating because client, e.g., SortedFederationStrategy, knows the
-          // Source exists.)
-          LOGGER.debug("CASE 3: New source {} detected - creating metrics", sourceId);
-          createMetric(
-              sourceId, METRICS_PREFIX + "." + QUERIES_TOTAL_RESULTS_SCOPE, MetricType.HISTOGRAM);
-          createMetric(sourceId, METRICS_PREFIX + "." + QUERIES_SCOPE, MetricType.COUNTER);
-          createMetric(sourceId, METRICS_PREFIX + "." + EXCEPTIONS_SCOPE, MetricType.COUNTER);
-
-          sourceToSourceIdMap.put(source, sourceId);
-        }
-        return true;
-      }
-    }
-
-    LOGGER.debug("Did not find source {} in Sources - cannot create metrics", sourceId);
-
-    return false;
-  }
-
-  /**
-   * Creates metrics for new CatalogProvider or FederatedSource when they are initially created.
-   * Metrics creation includes the JMX MBeans and associated ddf.metrics.collector.JmxCollector.
-   *
-   * @param source
-   * @param props
-   */
-  public void addingSource(final Source source, Map props) {
-    LOGGER.trace("ENTERING: addingSource");
-
-    if (executorPool == null) {
-      executorPool =
-          Executors.newCachedThreadPool(
-              StandardThreadFactoryBuilder.newThreadFactory("sourceMetricThread"));
-    }
-
-    // Creating JmxCollectors for all of the source metrics can be time consuming,
-    // so do this in a separate thread to prevent blacklisting by EventAdmin
-    final Runnable metricsCreator =
-        new Runnable() {
-          public void run() {
-            createSourceMetrics(source);
-          }
-        };
-
-    LOGGER.debug("Start metricsCreator thread for Source {}", source.getId());
-    executorPool.execute(metricsCreator);
-
-    LOGGER.trace("EXITING: addingSource");
-  }
-
-  /**
-   * Deletes metrics for existing CatalogProvider or FederatedSource when they are deleted. Metrics
-   * deletion includes the JMX MBeans and associated ddf.metrics.collector.JmxCollector.
-   *
-   * @param source
-   * @param props
-   */
-  public void deletingSource(final Source source, final Map props) {
-    LOGGER.trace("ENTERING: deletingSource");
-
-    if (source == null || StringUtils.isBlank(source.getId())) {
-      LOGGER.debug("Not deleting metrics for NULL or blank source");
-      return;
-    }
-
-    String sourceId = source.getId();
-
-    LOGGER.debug("sourceId = {},    props = {}", sourceId, props);
-
-    // Delete source from internal map used when updating metrics by sourceId
-    sourceToSourceIdMap.remove(source);
-
-    LOGGER.trace("EXITING: deletingSource");
-  }
-
-  // Separate, package-scope method to allow unit testing
-  void createSourceMetrics(final Source source) {
-
-    if (source == null || StringUtils.isBlank(source.getId())) {
-      LOGGER.debug("Not adding metrics for NULL or blank source");
-      return;
-    }
-
-    String sourceId = source.getId();
-
-    LOGGER.debug("sourceId = {}", sourceId);
-
-    createMetric(sourceId, METRICS_PREFIX + QUERIES_TOTAL_RESULTS_SCOPE, MetricType.HISTOGRAM);
-    createMetric(sourceId, METRICS_PREFIX + QUERIES_SCOPE, MetricType.COUNTER);
-    createMetric(sourceId, METRICS_PREFIX + EXCEPTIONS_SCOPE, MetricType.COUNTER);
-
-    // Add new source to internal map used when updating metrics by sourceId
-    sourceToSourceIdMap.put(source, sourceId);
-  }
-
-  private void createMetric(String sourceId, String mbeanName, MetricType type) {
-
-    // Create source-specific metrics for this source
-    String key = sourceId + "." + mbeanName;
-
-    // Do not create metric and collector if they already exist for this source.
-    // (This can happen for ConnectedSources because they have the same sourceId
-    // as the local catalog provider).
-    if (!metrics.containsKey(key)) {
-      if (type == MetricType.HISTOGRAM) {
-        DistributionSummary histogram = meterRegistry.summary(mbeanName);
-        metrics.put(key, new SourceMetric(histogram, true));
-      } else if (type == MetricType.COUNTER) {
-        Counter counter = meterRegistry.counter(mbeanName);
-        metrics.put(key, new SourceMetric(counter));
-      } else {
-        LOGGER.debug("Metric {} not created because unknown metric type {} specified.", key, type);
-      }
-    } else {
-      LOGGER.debug("Metric {} already exists - not creating again", key);
-    }
-  }
-
-  // The types of Micrometer Metrics supported
-  private enum MetricType {
-    HISTOGRAM,
-    COUNTER
-  }
-
-  /**
-   * Inner class POJO to maintain details of each metric for each Source.
-   *
-   * @author rodgersh
-   */
-  public static class SourceMetric {
-
-    // The Micrometer Meter
-    private Meter metric;
-
-    // Whether this metric is a Histogram or Counter
-    private boolean isHistogram = false;
-
-    public SourceMetric(Meter metric) {
-      this(metric, false);
-    }
-
-    public SourceMetric(Meter metric, boolean isHistogram) {
-      this.metric = metric;
-      this.isHistogram = isHistogram;
-    }
-
-    public Meter getMetric() {
-      return metric;
-    }
-
-    public boolean isHistogram() {
-      return isHistogram;
-    }
   }
 }

--- a/catalog/core/catalog-core-sourcemetricsplugin/src/main/java/ddf/catalog/metrics/source/SourceMetricsImpl.java
+++ b/catalog/core/catalog-core-sourcemetricsplugin/src/main/java/ddf/catalog/metrics/source/SourceMetricsImpl.java
@@ -13,6 +13,7 @@
  */
 package ddf.catalog.metrics.source;
 
+import ddf.catalog.data.Metacard;
 import ddf.catalog.data.Result;
 import ddf.catalog.operation.ProcessingDetails;
 import ddf.catalog.operation.QueryRequest;
@@ -21,15 +22,14 @@ import ddf.catalog.plugin.PluginExecutionException;
 import ddf.catalog.plugin.PostFederatedQueryPlugin;
 import ddf.catalog.plugin.PreFederatedQueryPlugin;
 import ddf.catalog.plugin.StopProcessingException;
-import ddf.catalog.source.CatalogProvider;
-import ddf.catalog.source.FederatedSource;
 import ddf.catalog.source.Source;
 import io.micrometer.core.instrument.MeterRegistry;
 import org.codice.ddf.lib.metrics.registry.MeterRegistryService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.*;
+import java.util.List;
+import java.util.Set;
 
 import static ddf.catalog.source.SourceMetrics.*;
 
@@ -51,11 +51,9 @@ public class SourceMetricsImpl implements PreFederatedQueryPlugin, PostFederated
   public QueryRequest process(Source source, QueryRequest input)
       throws PluginExecutionException, StopProcessingException {
 
-//    A DistributionSummary can be instead by replacing counter() by summary() and increment() by record. This applies
+//    A DistributionSummary can be instead by replacing counter() by summary() and increment() by record(). This applies
 //    equally to any other metric set in this class and retrieved in SourceMetricImplTest
-    meterRegistry.counter(source.getId() + "." + METRICS_PREFIX + "." +
-            QUERY_SCOPE + "." + REQUEST_TYPE)
-            .increment();
+    meterRegistry.counter(source.getId() + "." + METRICS_PREFIX + "." + QUERY_SCOPE + "." + REQUEST_TYPE).increment();
     return input;
   }
 
@@ -64,33 +62,24 @@ public class SourceMetricsImpl implements PreFederatedQueryPlugin, PostFederated
   public QueryResponse process(QueryResponse input)
       throws PluginExecutionException, StopProcessingException {
 
-    LOGGER.trace("ENTERING: process (for PostFederatedQueryPlugin)");
-
-    if (null != input) {
+    if (input != null) {
       Set<ProcessingDetails> processingDetails = input.getProcessingDetails();
       List<Result> results = input.getResults();
 
-      Iterator<ProcessingDetails> iterator = processingDetails.iterator();
-      while (iterator.hasNext()) {
-        ProcessingDetails next = iterator.next();
-        if (next != null && next.getException() != null) {
-          String sourceId = next.getSourceId();
-          meterRegistry.counter(sourceId + "." + METRICS_PREFIX + "." + QUERY_SCOPE + "."+ EXCEPTION_TYPE).increment();
-        }
-      }
+      processingDetails.stream()
+              .filter(ProcessingDetails::hasException)
+              .map(ProcessingDetails::getSourceId)
+              .forEach(id -> {
+                meterRegistry.counter(id  + "." + METRICS_PREFIX + "." + QUERY_SCOPE + "."+ EXCEPTION_TYPE).increment();
+              });
 
-      Map<String, Integer> totalHitsPerSource = new HashMap<String, Integer>();
-      for (Result result : results) {
-        String sourceId = result.getMetacard().getSourceId();
-        totalHitsPerSource.put(sourceId, totalHitsPerSource.getOrDefault(sourceId, 0));
-      }
-      for (Map.Entry<String, Integer> source : totalHitsPerSource.entrySet()) {
-        meterRegistry.counter(source.getKey() + "." + METRICS_PREFIX + "." + QUERY_SCOPE + "." + RESPONSE_TYPE).increment();
-      }
+      results.stream()
+              .map(Result::getMetacard)
+              .map(Metacard::getSourceId)
+              .forEach(id -> {
+                meterRegistry.counter(id  + "." + METRICS_PREFIX + "." + QUERY_SCOPE + "."+ RESPONSE_TYPE).increment();
+              });
     }
-
-    LOGGER.trace("EXITING: process (for PostFederatedQueryPlugin)");
-
     return input;
   }
 }

--- a/catalog/core/catalog-core-sourcemetricsplugin/src/test/java/ddf/catalog/metrics/source/SourceMetricsImplTest.java
+++ b/catalog/core/catalog-core-sourcemetricsplugin/src/test/java/ddf/catalog/metrics/source/SourceMetricsImplTest.java
@@ -21,8 +21,6 @@ import ddf.catalog.operation.QueryResponse;
 import ddf.catalog.operation.impl.ProcessingDetailsImpl;
 import ddf.catalog.plugin.PluginExecutionException;
 import ddf.catalog.plugin.StopProcessingException;
-import ddf.catalog.source.CatalogProvider;
-import ddf.catalog.source.FederatedSource;
 import ddf.catalog.source.Source;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
@@ -43,17 +41,12 @@ import static org.hamcrest.Matchers.is;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-//import ddf.catalog.source.SourceMetrics;
 
 public class SourceMetricsImplTest {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(SourceMetricsImplTest.class);
 
   private SourceMetricsImpl sourceMetrics;
-
-  private CatalogProvider catalogProvider;
-
-  private FederatedSource fedSource;
 
   private SourceMetricsImpl sourceMetricsImpl;
 

--- a/platform/metrics/platform-metrics-interceptor/src/main/java/ddf/metrics/interceptor/MetricsInInterceptor.java
+++ b/platform/metrics/platform-metrics-interceptor/src/main/java/ddf/metrics/interceptor/MetricsInInterceptor.java
@@ -29,8 +29,6 @@ import org.codice.ddf.lib.metrics.registry.MeterRegistryService;
  */
 public class MetricsInInterceptor extends AbstractMetricsInterceptor {
 
-  static final String TIME_IN = "TimeIn";
-
   public MetricsInInterceptor(MeterRegistryService meterRegistryService) {
     super(Phase.RECEIVE, meterRegistryService);
   }

--- a/platform/metrics/platform-metrics-interceptor/src/main/java/ddf/metrics/interceptor/MetricsOutInterceptor.java
+++ b/platform/metrics/platform-metrics-interceptor/src/main/java/ddf/metrics/interceptor/MetricsOutInterceptor.java
@@ -45,6 +45,10 @@ public class MetricsOutInterceptor extends AbstractMetricsInterceptor {
 
     Exchange ex = message.getExchange();
 
+    if (ex == null) {
+      return;
+    }
+
     if (Boolean.TRUE.equals(message.get(Message.PARTIAL_RESPONSE_MESSAGE))) {
       return;
     }

--- a/platform/metrics/platform-metrics-interceptor/src/test/java/ddf/metrics/interceptor/MetricsInInterceptorTest.java
+++ b/platform/metrics/platform-metrics-interceptor/src/test/java/ddf/metrics/interceptor/MetricsInInterceptorTest.java
@@ -13,25 +13,43 @@
  */
 package ddf.metrics.interceptor;
 
-import static org.hamcrest.CoreMatchers.instanceOf;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThat;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-
-import org.apache.cxf.Bus;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.apache.cxf.message.Exchange;
 import org.apache.cxf.message.ExchangeImpl;
 import org.apache.cxf.message.Message;
 import org.apache.cxf.phase.Phase;
 import org.codice.ddf.lib.metrics.registry.MeterRegistryService;
+import org.junit.Before;
 import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
 
 /** @author willisod */
 public class MetricsInInterceptorTest {
+
+  private Exchange exchange;
+
+  private LatencyTimeRecorder latencyTimeRecorder;
+
+  private Message message;
+
+  private MetricsInInterceptor metricsInInterceptor;
+
+  @Before
+  public void init() {
+    MeterRegistry meterRegistry = new SimpleMeterRegistry();
+    MeterRegistryService meterRegistryService = mock(MeterRegistryService.class);
+    when(meterRegistryService.getMeterRegistry()).thenReturn(meterRegistry);
+    metricsInInterceptor = new MetricsInInterceptor(meterRegistryService);
+
+    message = mock(Message.class);
+    exchange = spy(ExchangeImpl.class);
+    latencyTimeRecorder = mock(LatencyTimeRecorder.class);
+    when(message.getExchange()).thenReturn(exchange);
+  }
 
   /**
    * Test method for {@link
@@ -39,166 +57,7 @@ public class MetricsInInterceptorTest {
    */
   @Test
   public void testMetricsInInterceptor() {
-
-    // Perform test
-    MetricsInInterceptor inInterceptor = new MetricsInInterceptor(mock(MeterRegistryService.class));
-
-    // Validate
-    assertEquals(Phase.RECEIVE, inInterceptor.getPhase());
-  }
-
-  /**
-   * Test method for {@link
-   * ddf.metrics.interceptor.MetricsInInterceptor#handleMessage(org.apache.cxf.message.Message)} .
-   *
-   * @throws InterruptedException
-   */
-  @Test
-  public void testHandleMessageWithTwoWayClientMessageWithLatencyTimeRecorder() {
-
-    // Setup
-    MetricsInInterceptor inInterceptor = new MetricsInInterceptor(mock(MeterRegistryService.class));
-
-    Message mockMessage = mock(Message.class);
-    Exchange ex = new ExchangeImpl();
-    Bus mockBus = mock(Bus.class);
-    LatencyTimeRecorder mockLtr = mock(LatencyTimeRecorder.class);
-
-    ex.put(Bus.class, mockBus);
-    ex.put(LatencyTimeRecorder.class, mockLtr);
-
-    when(mockBus.getId()).thenReturn("bus_id");
-    when(mockMessage.getExchange()).thenReturn(ex);
-    when(mockMessage.get(Message.REQUESTOR_ROLE)).thenReturn(true);
-
-    // Perform test
-    inInterceptor.handleMessage(mockMessage);
-
-    // validate that LatencyTimeRecorder.beginHandling was called once
-    verify(mockLtr, times(1)).endHandling();
-  }
-
-  /**
-   * Test method for {@link
-   * ddf.metrics.interceptor.MetricsInInterceptor#handleMessage(org.apache.cxf.message.Message)} .
-   *
-   * @throws InterruptedException
-   */
-  @Test
-  public void testHandleMessageWithTwoWayClientMessageWithoutLatencyTimeRecorder() {
-
-    // Setup
-    MetricsInInterceptor inInterceptor = new MetricsInInterceptor(mock(MeterRegistryService.class));
-
-    Message mockMessage = mock(Message.class);
-    Exchange ex = new ExchangeImpl();
-    Bus mockBus = mock(Bus.class);
-
-    ex.put(Bus.class, mockBus);
-
-    when(mockBus.getId()).thenReturn("bus_id");
-    when(mockMessage.getExchange()).thenReturn(ex);
-    when(mockMessage.get(Message.REQUESTOR_ROLE)).thenReturn(true);
-
-    // Perform test
-    inInterceptor.handleMessage(mockMessage);
-
-    // validate that there is not an instance of LatencyTimeRecorder on the
-    // exchange
-    assertNull(ex.get(LatencyTimeRecorder.class));
-  }
-
-  /**
-   * Test method for {@link
-   * ddf.metrics.interceptor.MetricsInInterceptor#handleMessage(org.apache.cxf.message.Message)} .
-   *
-   * @throws InterruptedException
-   */
-  @Test
-  public void testHandleMessageWithOneWayClientMessage() {
-
-    // Setup
-    MetricsInInterceptor inInterceptor = new MetricsInInterceptor(mock(MeterRegistryService.class));
-
-    Message mockMessage = mock(Message.class);
-    Exchange ex = new ExchangeImpl();
-    Bus mockBus = mock(Bus.class);
-
-    ex.put(Bus.class, mockBus);
-    ex.setOneWay(true);
-
-    when(mockBus.getId()).thenReturn("bus_id");
-    when(mockMessage.getExchange()).thenReturn(ex);
-    when(mockMessage.get(Message.REQUESTOR_ROLE)).thenReturn(true);
-
-    // Perform test
-    inInterceptor.handleMessage(mockMessage);
-
-    // validate that there is not an instance of LatencyTimeRecorder on the
-    // exchange
-    assertNull(ex.get(LatencyTimeRecorder.class));
-  }
-
-  /**
-   * Test method for {@link
-   * ddf.metrics.interceptor.MetricsInInterceptor#handleMessage(org.apache.cxf.message.Message)} .
-   *
-   * @throws InterruptedException
-   */
-  @Test
-  public void testHandleMessageWithNonClientMessageWithoutLatencyTimeRecorder() {
-
-    // Setup
-    MetricsInInterceptor inInterceptor = new MetricsInInterceptor(mock(MeterRegistryService.class));
-
-    Message mockMessage = mock(Message.class);
-    Exchange ex = new ExchangeImpl();
-    Bus mockBus = mock(Bus.class);
-
-    ex.put(Bus.class, mockBus);
-
-    when(mockBus.getId()).thenReturn("bus_id");
-    when(mockMessage.getExchange()).thenReturn(ex);
-    when(mockMessage.get(Message.REQUESTOR_ROLE)).thenReturn("false");
-
-    // Perform test
-    inInterceptor.handleMessage(mockMessage);
-
-    // validate that an instance of LatencyTimeRecorder was put onto the
-    // exchange
-    assertThat(ex.get(LatencyTimeRecorder.class), instanceOf(LatencyTimeRecorder.class));
-  }
-
-  /**
-   * Test method for {@link
-   * ddf.metrics.interceptor.MetricsInInterceptor#handleMessage(org.apache.cxf.message.Message)} .
-   *
-   * @throws InterruptedException
-   */
-  @Test
-  public void testHandleMessageWithNonClientMessageWithLatencyTimeRecorder() {
-
-    // Setup
-    MetricsInInterceptor inInterceptor = new MetricsInInterceptor(mock(MeterRegistryService.class));
-
-    Message mockMessage = mock(Message.class);
-    Exchange ex = new ExchangeImpl();
-    Bus mockBus = mock(Bus.class);
-    LatencyTimeRecorder mockLtr = mock(LatencyTimeRecorder.class);
-
-    ex.put(Bus.class, mockBus);
-    ex.put(LatencyTimeRecorder.class, mockLtr);
-
-    when(mockBus.getId()).thenReturn("bus_id");
-    when(mockMessage.getExchange()).thenReturn(ex);
-    when(mockMessage.get(Message.REQUESTOR_ROLE)).thenReturn("false");
-
-    // Perform test
-    inInterceptor.handleMessage(mockMessage);
-
-    // validate that an instance of LatencyTimeRecorder was put onto the
-    // exchange
-    assertThat(ex.get(LatencyTimeRecorder.class), instanceOf(LatencyTimeRecorder.class));
+    assertEquals(Phase.RECEIVE, metricsInInterceptor.getPhase());
   }
 
   /**
@@ -209,18 +68,77 @@ public class MetricsInInterceptorTest {
    */
   @Test
   public void testHandleMessageWithoutExchange() {
+    Message messageWithoutExchange = mock(Message.class);
+    when(messageWithoutExchange.getExchange()).thenReturn(null);
+    metricsInInterceptor.handleMessage(messageWithoutExchange);
+    verify(messageWithoutExchange, never()).get(Message.REQUESTOR_ROLE);
+  }
 
-    // Setup
-    MetricsInInterceptor inInterceptor = new MetricsInInterceptor(mock(MeterRegistryService.class));
+  /**
+   * Test method for {@link
+   * ddf.metrics.interceptor.MetricsInInterceptor#handleMessage(org.apache.cxf.message.Message)} .
+   *
+   * @throws InterruptedException
+   */
+  @Test
+  public void testHandleMessageWithTwoWayClientMessageWithLatencyTimeRecorder() {
+    when(message.get(Message.REQUESTOR_ROLE)).thenReturn(true);
+    when(exchange.get(LatencyTimeRecorder.class)).thenReturn(latencyTimeRecorder);
+    metricsInInterceptor.handleMessage(message);
+    verify(latencyTimeRecorder, times(1)).endHandling();
+  }
 
-    Message mockMessage = mock(Message.class);
+  /**
+   * Test method for {@link
+   * ddf.metrics.interceptor.MetricsInInterceptor#handleMessage(org.apache.cxf.message.Message)} .
+   *
+   * @throws InterruptedException
+   */
+  @Test
+  public void testHandleMessageWithTwoWayClientMessageWithoutLatencyTimeRecorder() {
+    when(message.get(Message.REQUESTOR_ROLE)).thenReturn(true);
+    metricsInInterceptor.handleMessage(message);
+    assertNull(exchange.get(LatencyTimeRecorder.class));
+  }
 
-    when(mockMessage.getExchange()).thenReturn(null);
+  /**
+   * Test method for {@link
+   * ddf.metrics.interceptor.MetricsInInterceptor#handleMessage(org.apache.cxf.message.Message)} .
+   *
+   * @throws InterruptedException
+   */
+  @Test
+  public void testHandleMessageWithOneWayClientMessage() {
+    when(message.get(Message.REQUESTOR_ROLE)).thenReturn(true);
+    exchange.setOneWay(true);
+    metricsInInterceptor.handleMessage(message);
+    assertNull(exchange.get(LatencyTimeRecorder.class));
+  }
 
-    // Perform test
-    inInterceptor.handleMessage(mockMessage);
+  /**
+   * Test method for {@link
+   * ddf.metrics.interceptor.MetricsInInterceptor#handleMessage(org.apache.cxf.message.Message)} .
+   *
+   * @throws InterruptedException
+   */
+  @Test
+  public void testHandleMessageWithNonClientMessageWithLatencyTimeRecorder() {
+    when(message.get(Message.REQUESTOR_ROLE)).thenReturn(false);
+    when(exchange.get(LatencyTimeRecorder.class)).thenReturn(latencyTimeRecorder);
+    metricsInInterceptor.handleMessage(message);
+    verify(latencyTimeRecorder, times(1)).beginHandling();
+  }
 
-    // validate that Message.getExchange() was called once
-    verify(mockMessage, times(1)).getExchange();
+  /**
+   * Test method for {@link
+   * ddf.metrics.interceptor.MetricsInInterceptor#handleMessage(org.apache.cxf.message.Message)} .
+   *
+   * @throws InterruptedException
+   */
+  @Test
+  public void testHandleMessageWithNonClientMessageWithoutLatencyTimeRecorder() {
+    when(message.get(Message.REQUESTOR_ROLE)).thenReturn(false);
+    metricsInInterceptor.handleMessage(message);
+    assertThat(exchange.get(LatencyTimeRecorder.class), instanceOf(LatencyTimeRecorder.class));
   }
 }

--- a/platform/metrics/platform-metrics-interceptor/src/test/java/ddf/metrics/interceptor/MetricsInInterceptorTest.java
+++ b/platform/metrics/platform-metrics-interceptor/src/test/java/ddf/metrics/interceptor/MetricsInInterceptorTest.java
@@ -13,6 +13,10 @@
  */
 package ddf.metrics.interceptor;
 
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.apache.cxf.message.Exchange;
@@ -22,10 +26,6 @@ import org.apache.cxf.phase.Phase;
 import org.codice.ddf.lib.metrics.registry.MeterRegistryService;
 import org.junit.Before;
 import org.junit.Test;
-
-import static org.hamcrest.CoreMatchers.instanceOf;
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
 
 /** @author willisod */
 public class MetricsInInterceptorTest {

--- a/platform/metrics/platform-metrics-interceptor/src/test/java/ddf/metrics/interceptor/MetricsOutInterceptorTest.java
+++ b/platform/metrics/platform-metrics-interceptor/src/test/java/ddf/metrics/interceptor/MetricsOutInterceptorTest.java
@@ -20,9 +20,7 @@ import static org.junit.Assert.assertNull;
 import static org.mockito.Mockito.*;
 
 import io.micrometer.core.instrument.MeterRegistry;
-import io.micrometer.core.instrument.Metrics;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
-import org.apache.cxf.Bus;
 import org.apache.cxf.interceptor.InterceptorChain;
 import org.apache.cxf.message.Exchange;
 import org.apache.cxf.message.ExchangeImpl;

--- a/platform/metrics/platform-metrics-interceptor/src/test/java/ddf/metrics/interceptor/MetricsOutInterceptorTest.java
+++ b/platform/metrics/platform-metrics-interceptor/src/test/java/ddf/metrics/interceptor/MetricsOutInterceptorTest.java
@@ -17,11 +17,11 @@ import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Metrics;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.apache.cxf.Bus;
 import org.apache.cxf.interceptor.InterceptorChain;
 import org.apache.cxf.message.Exchange;
@@ -29,6 +29,7 @@ import org.apache.cxf.message.ExchangeImpl;
 import org.apache.cxf.message.Message;
 import org.apache.cxf.phase.Phase;
 import org.codice.ddf.lib.metrics.registry.MeterRegistryService;
+import org.junit.Before;
 import org.junit.Test;
 
 /** @author willisod */
@@ -38,15 +39,45 @@ public class MetricsOutInterceptorTest {
    * Test method for {@link
    * ddf.metrics.interceptor.MetricsOutInterceptor#MetricsOutInterceptor(MeterRegistryService)} .
    */
+  private Exchange exchange;
+
+  private LatencyTimeRecorder latencyTimeRecorder;
+
+  private Message message;
+
+  private MetricsOutInterceptor metricsOutInterceptor;
+
+  @Before
+  public void init() {
+    MeterRegistry meterRegistry = new SimpleMeterRegistry();
+    MeterRegistryService meterRegistryService = mock(MeterRegistryService.class);
+    when(meterRegistryService.getMeterRegistry()).thenReturn(meterRegistry);
+    metricsOutInterceptor = new MetricsOutInterceptor(meterRegistryService);
+
+    message = mock(Message.class);
+    exchange = spy(ExchangeImpl.class);
+    latencyTimeRecorder = mock(LatencyTimeRecorder.class);
+    when(message.get(Message.PARTIAL_RESPONSE_MESSAGE)).thenReturn(false);
+    when(message.getExchange()).thenReturn(exchange);
+  }
+
   @Test
   public void testMetricsOutInterceptor() {
+    assertEquals(Phase.SEND, metricsOutInterceptor.getPhase());
+  }
 
-    // Perform test
-    MetricsOutInterceptor outInterceptor =
-        new MetricsOutInterceptor(mock(MeterRegistryService.class));
-
-    // Validate
-    assertEquals(Phase.SEND, outInterceptor.getPhase());
+  /**
+   * Test method for {@link
+   * ddf.metrics.interceptor.MetricsOutInterceptor#handleMessage(org.apache.cxf.message.Message)} .
+   *
+   * @throws InterruptedException
+   */
+  @Test
+  public void testHandleMessageWithoutExchange() {
+    Message messageWithoutExchange = mock(Message.class);
+    when(messageWithoutExchange.getExchange()).thenReturn(null);
+    metricsOutInterceptor.handleMessage(messageWithoutExchange);
+    verify(messageWithoutExchange, never()).get(Message.PARTIAL_RESPONSE_MESSAGE);
   }
 
   /**
@@ -57,23 +88,10 @@ public class MetricsOutInterceptorTest {
    */
   @Test
   public void testHandleMessageWithPartialResponseMessage() {
-
-    // Setup
-    MetricsOutInterceptor outInterceptor =
-        new MetricsOutInterceptor(mock(MeterRegistryService.class));
-
-    Message mockMessage = mock(Message.class);
-    Exchange ex = new ExchangeImpl();
-
-    when(mockMessage.getExchange()).thenReturn(ex);
-    when(mockMessage.get(Message.PARTIAL_RESPONSE_MESSAGE)).thenReturn("true");
-
-    // Perform test
-    outInterceptor.handleMessage(mockMessage);
-
-    // validate that there is not an instance of LatencyTimeRecorder on the
-    // exchange
-    assertNull(ex.get(LatencyTimeRecorder.class));
+    Message partialMessage = mock(Message.class);
+    when(partialMessage.get(Message.PARTIAL_RESPONSE_MESSAGE)).thenReturn(true);
+    metricsOutInterceptor.handleMessage(partialMessage);
+    verify(partialMessage, never()).get(Message.REQUESTOR_ROLE);
   }
 
   /**
@@ -84,29 +102,10 @@ public class MetricsOutInterceptorTest {
    */
   @Test
   public void testHandleMessageWithTwoWayClientMessageWithLatencyTimeRecorder() {
-
-    // Setup
-    MetricsOutInterceptor outInterceptor =
-        new MetricsOutInterceptor(mock(MeterRegistryService.class));
-
-    Message mockMessage = mock(Message.class);
-    Exchange ex = new ExchangeImpl();
-    Bus mockBus = mock(Bus.class);
-    LatencyTimeRecorder mockLtr = mock(LatencyTimeRecorder.class);
-
-    ex.put(Bus.class, mockBus);
-    ex.put(LatencyTimeRecorder.class, mockLtr);
-
-    when(mockBus.getId()).thenReturn("bus_id");
-    when(mockMessage.getExchange()).thenReturn(ex);
-    when(mockMessage.get(Message.PARTIAL_RESPONSE_MESSAGE)).thenReturn("false");
-    when(mockMessage.get(Message.REQUESTOR_ROLE)).thenReturn(true);
-
-    // Perform test
-    outInterceptor.handleMessage(mockMessage);
-
-    // validate that LatencyTimeRecorder.beginHandling was called once
-    verify(mockLtr, times(1)).beginHandling();
+    when(message.get(Message.REQUESTOR_ROLE)).thenReturn(true);
+    when(exchange.get(LatencyTimeRecorder.class)).thenReturn(latencyTimeRecorder);
+    metricsOutInterceptor.handleMessage(message);
+    verify(latencyTimeRecorder, times(1)).beginHandling();
   }
 
   /**
@@ -117,28 +116,9 @@ public class MetricsOutInterceptorTest {
    */
   @Test
   public void testHandleMessageWithTwoWayClientMessageWithoutLatencyTimeRecorder() {
-
-    // Setup
-    MetricsOutInterceptor outInterceptor =
-        new MetricsOutInterceptor(mock(MeterRegistryService.class));
-
-    Message mockMessage = mock(Message.class);
-    Exchange ex = new ExchangeImpl();
-    Bus mockBus = mock(Bus.class);
-
-    ex.put(Bus.class, mockBus);
-
-    when(mockBus.getId()).thenReturn("bus_id");
-    when(mockMessage.getExchange()).thenReturn(ex);
-    when(mockMessage.get(Message.PARTIAL_RESPONSE_MESSAGE)).thenReturn("false");
-    when(mockMessage.get(Message.REQUESTOR_ROLE)).thenReturn(true);
-
-    // Perform test
-    outInterceptor.handleMessage(mockMessage);
-
-    // validate that an instance of LatencyTimeRecorder was put onto the
-    // exchange
-    assertThat(ex.get(LatencyTimeRecorder.class), instanceOf(LatencyTimeRecorder.class));
+    when(message.get(Message.REQUESTOR_ROLE)).thenReturn(true);
+    metricsOutInterceptor.handleMessage(message);
+    assertThat(exchange.get(LatencyTimeRecorder.class), instanceOf(LatencyTimeRecorder.class));
   }
 
   /**
@@ -149,30 +129,12 @@ public class MetricsOutInterceptorTest {
    */
   @Test
   public void testHandleMessageWithOneWayClientMessage() {
-
-    // Setup
-    MetricsOutInterceptor outInterceptor =
-        new MetricsOutInterceptor(mock(MeterRegistryService.class));
-
-    Message mockMessage = mock(Message.class);
-    Exchange ex = new ExchangeImpl();
-    Bus mockBus = mock(Bus.class);
-    InterceptorChain mockIc = mock(InterceptorChain.class);
-
-    ex.put(Bus.class, mockBus);
-    ex.setOneWay(true);
-
-    when(mockBus.getId()).thenReturn("bus_id");
-    when(mockMessage.getExchange()).thenReturn(ex);
-    when(mockMessage.get(Message.PARTIAL_RESPONSE_MESSAGE)).thenReturn("false");
-    when(mockMessage.get(Message.REQUESTOR_ROLE)).thenReturn(true);
-    when(mockMessage.getInterceptorChain()).thenReturn(mockIc);
-
-    // Perform test
-    outInterceptor.handleMessage(mockMessage);
-
-    // validate that LatencyTimeRecorder.beginHandling was called once
-    verify(mockMessage, times(1)).getInterceptorChain();
+    when(message.get(Message.REQUESTOR_ROLE)).thenReturn(true);
+    exchange.setOneWay(true);
+    InterceptorChain interceptorChain = mock(InterceptorChain.class);
+    when(message.getInterceptorChain()).thenReturn(interceptorChain);
+    metricsOutInterceptor.handleMessage(message);
+    verify(message, times(1)).getInterceptorChain();
   }
 
   /**
@@ -182,24 +144,11 @@ public class MetricsOutInterceptorTest {
    * @throws InterruptedException
    */
   @Test
-  public void testHandleMessageWithNonClientMessageWithNullExchange() {
-
-    // Setup
-    MetricsOutInterceptor outInterceptor =
-        new MetricsOutInterceptor(mock(MeterRegistryService.class));
-
-    Message mockMessage = mock(Message.class);
-
-    when(mockMessage.getExchange()).thenReturn(null);
-    when(mockMessage.get(Message.PARTIAL_RESPONSE_MESSAGE)).thenReturn("false");
-    when(mockMessage.get(Message.REQUESTOR_ROLE)).thenReturn("false");
-
-    // Perform test
-    outInterceptor.handleMessage(mockMessage);
-
-    // validate that there is not an instance of LatencyTimeRecorder on the
-    // exchange
-    verify(mockMessage, times(1)).getExchange();
+  public void testHandleMessageWithNonClientMessageWithLatencyTimeRecorder() {
+    when(message.get(Message.REQUESTOR_ROLE)).thenReturn(false);
+    when(exchange.get(LatencyTimeRecorder.class)).thenReturn(latencyTimeRecorder);
+    metricsOutInterceptor.handleMessage(message);
+    verify(latencyTimeRecorder, times(1)).endHandling();
   }
 
   /**
@@ -210,27 +159,8 @@ public class MetricsOutInterceptorTest {
    */
   @Test
   public void testHandleMessageWithNonClientMessageWithoutLatencyTimeRecorder() {
-
-    // Setup
-    MetricsOutInterceptor outInterceptor =
-        new MetricsOutInterceptor(mock(MeterRegistryService.class));
-
-    Message mockMessage = mock(Message.class);
-    Exchange ex = new ExchangeImpl();
-    Bus mockBus = mock(Bus.class);
-
-    ex.put(Bus.class, mockBus);
-
-    when(mockBus.getId()).thenReturn("bus_id");
-    when(mockMessage.getExchange()).thenReturn(ex);
-    when(mockMessage.get(Message.PARTIAL_RESPONSE_MESSAGE)).thenReturn("false");
-    when(mockMessage.get(Message.REQUESTOR_ROLE)).thenReturn("false");
-
-    // Perform test
-    outInterceptor.handleMessage(mockMessage);
-
-    // validate that there is not an instance of LatencyTimeRecorder on the
-    // exchange
-    assertNull(ex.get(LatencyTimeRecorder.class));
+    when(message.get(Message.REQUESTOR_ROLE)).thenReturn(false);
+    metricsOutInterceptor.handleMessage(message);
+    assertNull(exchange.get(LatencyTimeRecorder.class));
   }
 }


### PR DESCRIPTION
Justification for changes:

`metrics` map with `SourceMetric` was previously used to track metrics strictly within this class. Most of the logic in `SourceMetricsImpl` was built around it. This is now managed by `MeterRegistry`, and a method such as `meterRegistry.counter(...).increment(...), will create a new metric if none exists. On the testing side, the same method can be used to return the metric if it exists. 

Lists of `catalogProvider` and `federatedSource` were removed. Their only real purpose before was as part of the `sourceToSourceIdMap`, which was used to detect if their `sourceId` had changed. Since the new implementation will create a new metric if that situation, there is no issue.
